### PR TITLE
Update round log URLs

### DIFF
--- a/src/Domain/Round/Data/Round.php
+++ b/src/Domain/Round/Data/Round.php
@@ -287,22 +287,18 @@ class Round implements JsonSerializable
         if($this->getServer() && $this->getStartDatetime()) {
 
             $server = $this->getServer();
-            $name = strtolower($server->getIdentifier());
-            if('bagil' === $name) {
-                $name = 'basil'; //damn you to hell mso
-            }
             $date = explode(':', $this->getStartDatetime()->format('Y:m:d'));
-            $path = sprintf(
-                "/%s/data/logs/%s/%s/%s/round-%s",
-                $name,
+            $logs = sprintf(
+                "%sdata/logs/%s/%s/%s/round-%s",
+                str_replace('.download', '.org', $server->getPublicLogs()),
                 $date[0],
                 $date[1],
                 $date[2],
                 $this->getId()
             );
-            $this->setPublicLogs(sprintf("%s%s", ServerInformationService::PUBLIC_LOGS, $path));
+            $this->setPublicLogs($logs);
 
-            $this->setAdminLogs(sprintf("%s%s", ServerInformationService::ADMIN_LOGS, $path));
+            $this->setAdminLogs(str_replace('parsed-logs', 'raw-logs', $logs));
         }
         return $this;
     }

--- a/src/Domain/Server/Data/Server.php
+++ b/src/Domain/Server/Data/Server.php
@@ -4,11 +4,18 @@ namespace App\Domain\Server\Data;
 
 class Server
 {
-    public ?string $name;
-    public ?string $address;
-    public ?int $port;
-    public ?string $identifier;
     public ?string $gameLink;
+
+    public function __construct(
+        public ?string $name,
+        public ?string $address,
+        public ?int $port,
+        public ?string $identifier,
+        public ?string $publicLogs,
+        public ?string $rawlogs
+    ) {
+        $this->setGameServerAddress();
+    }
 
     public function getName(): ?string
     {
@@ -69,6 +76,16 @@ class Server
         return $this;
     }
 
+    public function getPublicLogs(): ?string
+    {
+        return $this->publicLogs;
+    }
+
+
+    public function getAdminLogs(): ?string
+    {
+        return $this->rawlogs;
+    }
     public static function fromArray(array $data): self
     {
         $server = new self();

--- a/src/Service/ServerInformationService.php
+++ b/src/Service/ServerInformationService.php
@@ -43,12 +43,15 @@ class ServerInformationService
         foreach($data as $server) {
             if(isset($server['serverdata'])) {
                 if($port === $server['serverdata']['port']) {
-                    if(isset($server['identifier'])) {
-                        $server['serverdata']['identifier'] = $server['identifier'];
-                    } else {
-                        $server['serverdata']['identifier'] = explode(' ', $server['serverdata']['servername'])[0];
-                    }
-                    return Server::fromArray($server['serverdata']);
+                    $server = $server['serverdata'];
+                    return new Server(
+                        $server['dbname'],
+                        $server['address'],
+                        $server['port'],
+                        $server['dbname'],
+                        $server['publiclogsurl'],
+                        $server['rawlogsurl']
+                    );
                 }
             }
         }


### PR DESCRIPTION
The `serverinfo.json` provides data about where the logs can be found. Which is great, except: 

- Campbell doesn't have any log URLs
- Some of the servers randomly use `tgstation13.download` instead of `tgstation13.org`

Once these have been resolved I can finish this PR. 