### PR TITLE
Add IP Authentication and Refactor User Loading as Middleware

### DIFF
--- a/app/container.php
+++ b/app/container.php
@@ -100,7 +100,6 @@ return [
         $twig->getEnvironment()->addGlobal("debug", $config["debug"]);
         $twig->getEnvironment()->addGlobal("app", $config["app"]);
         $twig->getEnvironment()->addGlobal("flash", $session->getFlashBag()->all());
-        $twig->getEnvironment()->addGlobal("user", $container->get(User::class));
 
         $twig->addExtension(new \Twig\Extension\DebugExtension());
         $twig->addExtension(new WebpackAssetLoader($options));
@@ -162,18 +161,6 @@ return [
         } catch (Exception $e) {
             die("The /tg/station database is not available. This should be a temporary error.");
         }
-    },
-
-    User::class => function (ContainerInterface $containerInterface) {
-        $userRepository = new UserRepository($containerInterface->get(Connection::class), $containerInterface->get(EasyDB::class));
-        $session = $containerInterface->get(Session::class);
-        $ckey = $session->get('ckey');
-        if(!$ckey) {
-            return null;
-        }
-        $user = $userRepository->getUserByCkey($ckey);
-        $user->setSource($session->get('authSource'));
-        return $user;
     },
 
     LoggerFactory::class => function (ContainerInterface $container) {

--- a/app/defaults.php
+++ b/app/defaults.php
@@ -128,4 +128,13 @@ $settings['auth'] = [
   ]
 ];
 
+// Enables authentication of users by IP address from the BYOND connection log
+$settings['ip_auth'] = false;
+// If behind cloudflare or a reverse proxy, enable this setting to retrieve IPs from forward headers
+// !! SECURITY RISK IF ENABLED WITHOUT PROPER PROXY CONFIGURATION !!
+// !! MAKE SURE YOU ARE 100% CERTAIN CLIENTS CANNOT SPOOF PROXY HEADERS BEFORE ENABLING !!
+$settings['check_proxy_headers'] = false;
+// If above enabled, this can be adjusted to use the correct headers, likely either CF-Connecting-IP or X-Forwarded-For
+$settings['proxy_headers'] = ['CF-Connecting-IP'];
+
 return $settings;

--- a/app/middleware.php
+++ b/app/middleware.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Middleware\ExceptionMiddleware;
+use App\Middleware\UserMiddleware;
 use Slim\App;
 use Slim\Views\TwigMiddleware;
 use Middlewares\TrailingSlash;
 use Slim\Views\Twig;
+use RKA\Middleware\IpAddress;
 use Zeuxisoo\Whoops\Slim\WhoopsMiddleware;
 
 return function (App $app) {
@@ -12,6 +14,10 @@ return function (App $app) {
     $app->addRoutingMiddleware();
     $app->add(TwigMiddleware::create($app, $app->getContainer()->get(Twig::class)));
     $app->add(ExceptionMiddleware::class);
+    $app->add(UserMiddleware::class);
     $app->add(new TrailingSlash());
+    $settings = $app->getContainer()->get('settings');
+    $app->add(new IpAddress(checkProxyHeaders: $settings['check_proxy_headers'], trustedProxies: [], headersToInspect: $settings['proxy_headers']));
+
     // $app->add(new WhoopsMiddleware());
 };

--- a/app/routes.php
+++ b/app/routes.php
@@ -100,7 +100,7 @@ return function (App $app) {
         $app->map(['GET','POST'], "/{book:[0-9]+}", \App\Controller\Library\LibraryBookController::class)->setName("library.book");
         $app->get("/dupes", \App\Controller\Library\LibraryDuplicateController::class)->setName("library.dupes");
     })->add(function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
-        $request = $request->withAttribute('user', true);
+        $request = $request->withAttribute('authenticated', true);
         $response = $handler->handle($request);
         return $response;
     });

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/uid": "^6.3",
         "kevinrob/guzzle-cache-middleware": "^4.1",
         "twig/string-extra": "^3.7",
-        "paragonie/easydb-cache": "^2.0"
+        "paragonie/easydb-cache": "^2.0",
+        "akrabat/ip-address-middleware": "^2.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f30d7682a30d037d8559a9bc843fcac6",
+    "content-hash": "776568d5aee0d33cc260b3e5ea02586a",
     "packages": [
+        {
+            "name": "akrabat/ip-address-middleware",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/akrabat/ip-address-middleware.git",
+                "reference": "00a053e8513620f55a827e837d1468ec8b1264db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/akrabat/ip-address-middleware/zipball/00a053e8513620f55a827e837d1468ec8b1264db",
+                "reference": "00a053e8513620f55a827e837d1468ec8b1264db",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "replace": {
+                "akrabat/rka-ip-address-middleware": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^2.4 || ^3.0",
+                "phpunit/phpunit": "^8.5.8 || ^9.4",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "RKA\\Middleware\\Mezzio\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "RKA\\Middleware\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Allen",
+                    "email": "rob@akrabat.com",
+                    "homepage": "http://akrabat.com"
+                }
+            ],
+            "description": "PSR-15 middleware that determines the client IP address and stores it as a ServerRequest attribute",
+            "homepage": "http://github.com/akrabat/rka-ip-address-middleware",
+            "keywords": [
+                "IP",
+                "middleware",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/akrabat/ip-address-middleware/issues",
+                "source": "https://github.com/akrabat/ip-address-middleware/tree/2.5.0"
+            },
+            "time": "2024-12-19T20:26:01+00:00"
+        },
         {
             "name": "cakephp/cache",
             "version": "3.9.4",
@@ -6516,10 +6579,10 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -28,7 +28,6 @@ abstract class Controller
     public function __construct(
         protected ContainerInterface $container
     ) {
-        $this->user = $this->container->get('User');
         $this->session = $this->container->get(Session::class);
     }
 
@@ -143,6 +142,7 @@ abstract class Controller
         $this->setQuery();
         $this->setArgs($args);
         $this->setRoute();
+        $this->setUser($request->getAttribute('user'));
         $this->permissionCheck();
         $this->method = $this->request->getMethod();
         return $this->action();
@@ -246,6 +246,12 @@ abstract class Controller
         return $this->user;
     }
 
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
     /**
      * Verify that the current logged in user has the permission required
      * by the request attribute. Throws an exception if this check fails, or
@@ -256,7 +262,7 @@ abstract class Controller
     private function permissionCheck(): void
     {
         $user = $this->getUser();
-        $activeUser = $this->getRequest()->getAttribute('user');
+        $activeUser = $this->getRequest()->getAttribute('authenticated');
         if($activeUser) {
             if(!$user) {
                 throw new StatbusUnauthorizedException("You must be logged in to access this", 403);

--- a/src/Domain/User/Repository/UserRepository.php
+++ b/src/Domain/User/Repository/UserRepository.php
@@ -22,4 +22,19 @@ class UserRepository extends Repository
         ->fetch('assoc');
         return User::fromArray($user);
     }
+
+    public function getUserByLastIp(string $ip): ?User
+    {
+        $res = $this->connection
+        ->execute("SELECT
+        ckey, datetime FROM connection_log WHERE ip = :ip
+        ORDER BY id DESC LIMIT 1", ['ip' => ip2long($ip)])->fetch('assoc');
+
+        // Connection is rendered stale if older than 7 days
+        if(!is_array($res) || date_diff(new \DateTime($res['datetime']), new \DateTime())->d > 7) {
+            return null;
+        }
+
+        return $this->getUserByCkey($res['ckey']);
+    }
 }

--- a/src/Domain/User/Service/AuthenticateUser.php
+++ b/src/Domain/User/Service/AuthenticateUser.php
@@ -53,4 +53,19 @@ class AuthenticateUser
         return $user;
     }
 
+    public function authenticateUserFromIp(string $ip): ?User
+    {
+        $user = $this->userRepository->getUserByLastIp($ip);
+        if(!$user) {
+            return null;
+        }
+
+        $user->setSource('ip');
+        $this->session->set('authSource', 'ip');
+
+        $this->session->set('ckey', $user->getCkey());
+
+        return $user;
+    }
+
 }

--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -36,7 +36,6 @@ class ExceptionMiddleware extends Controller implements MiddlewareInterface
         $logger = $log = new Logger('stdout');
         $log->pushHandler(new StreamHandler('php://stdout', Logger::DEBUG));
         $this->logger = $logger;
-        $this->user = $containerInterface->get('User');
     }
 
     public function action(): ResponseInterface
@@ -46,6 +45,7 @@ class ExceptionMiddleware extends Controller implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        $this->setUser($request->getAttribute('user'));
         $twig = $this->containerInterface->get(Twig::class);
         try {
             return $handler->handle($request);

--- a/src/Middleware/UserMiddleware.php
+++ b/src/Middleware/UserMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Middleware;
+
+use App\Domain\User\Repository\UserRepository;
+use App\Domain\User\Service\AuthenticateUser;
+use Cake\Database\Connection;
+use ParagonIE\EasyDB\EasyDB;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Views\Twig;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+/**
+ * Loads information about an associated user from the session,
+ * pulls their information from the database and stores it in the request's attributes.
+ */
+class UserMiddleware implements MiddlewareInterface
+{
+    private UserRepository $userRepository;
+
+    private Session $session;
+    
+    private Twig $twig;
+
+    public function __construct(
+        private ContainerInterface $containerInterface,
+        private AuthenticateUser $auth
+    ) {
+        $this->userRepository = new UserRepository($containerInterface->get(Connection::class), $containerInterface->get(EasyDB::class));
+        $this->session = $containerInterface->get(Session::class);
+        $this->twig = $containerInterface->get(Twig::class);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $ckey = $this->session->get('ckey');
+        $user = null;
+
+        if($ckey) {
+            $user = $this->userRepository->getUserByCkey($ckey);
+            $user->setSource($this->session->get('authSource'));
+        } else {
+            // If user not stored, attempt to retrieve user based on IP address, if enabled, and authenticate automatically
+            if($this->containerInterface->get('settings')['ip_auth']) {
+                $user = $this->auth->authenticateUserFromIp($request->getAttribute('ip_address'));
+            }
+        }
+
+        $this->twig->getEnvironment()->addGlobal('user', $user);
+
+        return $handler->handle($request->withAttribute('user', $user));
+    }
+}


### PR DESCRIPTION
This PR implements fully optional IP address authentication as an option on Statbus, similar to the original Slimbus.

This is useful for downstreams that may not have the same OAuth facilities configured as /tg/station, but still would like to use statbus on their server.

Due to the requirements of implementing this functionality, loading user data from the session has been moved in a Middleware class, which I think is a better solution than storing dynamic information in the container, which per PSR-15 has no mutability once built.