### PR TITLE
Change ConnDB wildcards to optimize querying connections

### DIFF
--- a/src/Repository/ConnectionRepository.php
+++ b/src/Repository/ConnectionRepository.php
@@ -33,11 +33,11 @@ class ConnectionRepository extends TGRepository
         $qb = $this->getBaseQuery();
         if ($ckey) {
             $qb->orWhere('ckey LIKE :ckey')
-                ->setParameter('ckey', '%' . $ckey . '%');
+                ->setParameter('ckey', $ckey . '%');
         }
         if ($cid) {
             $qb->orWhere('computerid LIKE :cid')
-                ->setParameter('cid', '%' . $cid . '%');
+                ->setParameter('cid', $cid);
         }
         if ($ip) {
             if ($ip instanceof Network) {


### PR DESCRIPTION
SQL cannot make use of indexes if LIKE starts with a wildcard
CIDs do not need a wildcard anyways